### PR TITLE
Complete/Edit/Delete Chore Updating

### DIFF
--- a/frontend/app/(app)/chores.tsx
+++ b/frontend/app/(app)/chores.tsx
@@ -145,7 +145,6 @@ export default function ChoresScreen() {
       );
     } else {
       setSelectedChore(chore);
-      setAndroidMenuVisible(true);
     }
   };
 
@@ -222,6 +221,7 @@ export default function ChoresScreen() {
             <DateTimePickerModal
               isVisible={isDatePickerVisible}
               mode="date"
+              minimumDate={new Date()}
               onConfirm={(date) => {
                 setDueDate(date.toISOString());
                 setDatePickerVisible(false);

--- a/frontend/app/(app)/chores.tsx
+++ b/frontend/app/(app)/chores.tsx
@@ -32,7 +32,7 @@ const initialMockChores: Chore[] = [
 ];
 
 export default function ChoresScreen() {
-  const [chores, setChores] = useState<Chore[]>(() => JSON.parse(JSON.stringify(initialMockChores)));
+  const [chores, setChores] = useState<Chore[]>(() => JSON.parse(JSON.stringify(initialMockChores))); // deep copy so each object in chores gets its own memory reference
   const [modalVisible, setModalVisible] = useState(false);
   const [newChoreName, setNewChoreName] = useState("");
   const [roommate, setRoommate] = useState("");
@@ -63,9 +63,15 @@ export default function ChoresScreen() {
     }
   }, [selectedChore]);
 
-  const yourChores = chores.filter((chore) => chore.roommate_responsible === currentUser);
-  const roommatesChores = chores.filter((chore) => chore.roommate_responsible !== currentUser);
+  // dynamically update 
+  const [yourChores, setYourChores] = useState<Chore[]>([]);
+  const [roommatesChores, setRoommatesChores] = useState<Chore[]>([]);
 
+  useEffect(() => {
+    setYourChores(chores.filter((chore) => chore.roommate_responsible === currentUser));
+    setRoommatesChores(chores.filter((chore) => chore.roommate_responsible !== currentUser));
+  }, [chores]);
+  
   const addOrUpdateChore = () => {
     if (!newChoreName.trim() || !roommate.trim() || !dueDate) return;
 

--- a/frontend/app/(app)/chores.tsx
+++ b/frontend/app/(app)/chores.tsx
@@ -11,6 +11,7 @@ import {
   KeyboardAvoidingView,
   Platform,
   Animated,
+  ActionSheetIOS,
 } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
 import DateTimePickerModal from "react-native-modal-datetime-picker";
@@ -118,6 +119,34 @@ export default function ChoresScreen() {
     setChores((prevChores) => prevChores.filter((chore) => chore.id !== id));
   };
 
+  const remindChore = (chore: Chore) => {
+    alert(`Reminder sent for ${chore.name}!`);
+  };
+
+  const openActionMenu = (chore: Chore) => {
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          options: ["Remind", "Mark as Complete", "Edit", "Delete", "Cancel"],
+          destructiveButtonIndex: 3,
+          cancelButtonIndex: 4,
+        },
+        (buttonIndex) => {
+          if (buttonIndex === 0) remindChore(chore);
+          else if (buttonIndex === 1) toggleComplete(chore.id);
+          else if (buttonIndex === 2) {
+            setSelectedChore(chore);
+            setModalVisible(true);
+          }
+          else if (buttonIndex === 3) deleteChore(chore.id);
+        }
+      );
+    } else {
+      setSelectedChore(chore);
+      setAndroidMenuVisible(true);
+    }
+  };
+
   const renderChoreRow = ({ item }: { item: Chore }) => (
     <View style={[styles.choreRow, item.completed && styles.completedRow]}>
       <View style={styles.avatar}>
@@ -129,24 +158,12 @@ export default function ChoresScreen() {
         </Text>
         <Text style={styles.choreDate}>Ends: {new Date(item.ends).toLocaleDateString()}</Text>
       </View>
-      <TouchableOpacity onPress={() => toggleComplete(item.id)}>
-        <MaterialIcons
-          name={item.completed ? "check-circle" : "radio-button-unchecked"}
-          size={24}
-          color={item.completed ? "#00D09E" : "#666"}
-        />
-      </TouchableOpacity>
-      <TouchableOpacity onPress={() => deleteChore(item.id)}>
-        <MaterialIcons name="delete" size={24} color="#FF4C4C" />
-      </TouchableOpacity>
-      <TouchableOpacity onPress={() => {
-        setSelectedChore(item);
-        setModalVisible(true);
-      }}>
-        <MaterialIcons name="edit" size={24} color="#007FFF" />
+      <TouchableOpacity onPress={() => openActionMenu(item)}>
+        <MaterialIcons name="more-vert" size={24} color="#666" />
       </TouchableOpacity>
     </View>
   );
+
 
   return (
     <View style={styles.container}>

--- a/frontend/app/(app)/chores.tsx
+++ b/frontend/app/(app)/chores.tsx
@@ -124,10 +124,12 @@ export default function ChoresScreen() {
   };
 
   const openActionMenu = (chore: Chore) => {
+    const completeActionLabel = chore.completed ? "Mark as Incomplete" : "Mark as Complete";
+
     if (Platform.OS === "ios") {
       ActionSheetIOS.showActionSheetWithOptions(
         {
-          options: ["Remind", "Mark as Complete", "Edit", "Delete", "Cancel"],
+          options: ["Remind", completeActionLabel, "Edit", "Delete", "Cancel"],
           destructiveButtonIndex: 3,
           cancelButtonIndex: 4,
         },


### PR DESCRIPTION
The commits are a bit messy.
### **Changes Made:**
1. Added `completed` property in the `Chore` type
2. Changed state initialization for `chores` to a deep copy
- There were some memory reference issues when the list was updated
3. Added `toggleCompleted` function so user can mark as complete or incomplete
4. Added `deleteChore` function 
5. Added `selectedChore` state and `useEffect` for autofilling the form
- To track the chore being edited and autofill the form fields when `edit` is selected. `useEffect` updates the form inputs based on the currently selected chore
6. Replaced `addChore` with `addOrUpdateChore`
- To update existing chore instead of adding a new one
8. Added `resetModal` to clear the form after saving or canceling
9. Added dropdown menu `ActionSheetIOS`
10. Updated `renderChoreRow` to include the dropdown menu

### **Summary**:
Added functionality to toggle completed, delete, edit and remind chores. Added dropdown menu.

### **Notes**:
Now that we can complete chores, in a future PR we can consider moving them to a place for completed chores or getting rid of them—not sure yet.

### **Testing**:
On expo go:
Clicking on the 3 dots brings up a drop down menu:
<img src="https://github.com/user-attachments/assets/5c3351c5-c2ef-4bce-8cd9-5a2c5764b0b3" alt="IMG_4353" width="200">

We can mark it as complete:
<img src="https://github.com/user-attachments/assets/f1f9298a-fcf1-4dd5-822e-628f1d8cc919" alt="IMG_4353" width="200">

Or edit (editing the responsible roomate):
<img src="https://github.com/user-attachments/assets/21d27139-351d-4097-9c0c-661a1c241265" alt="IMG_4353" width="200">

The change is reflected:
<img src="https://github.com/user-attachments/assets/1b375739-7362-47b9-9e71-cecd7c3a7672" alt="IMG_4353" width="200">



