### PR TITLE
Divergent Migration Heads Fix

### DIFF
--- a/backend/migrations/versions/ce6050036851_added_expense_period_data_tables.py
+++ b/backend/migrations/versions/ce6050036851_added_expense_period_data_tables.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'ce6050036851'
-down_revision = '187e756c1069'
+down_revision = '909fe4f32d46'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
I was getting the following error when trying to set up the backend to get it running so I could look at it:
```
backend-1  | ERROR [flask_migrate] Error: Multiple head revisions are present for given argument 'head'; please specify a specific target revision, '<branchname>@head' to narrow to a specific head, or 'heads' for all heads
```

Alembic was seeing divergent migration heads because `backend/migrations/versions/909fe4f32d46_create_chores_table.py` and `backend/migrations/versions/ce6050036851_added_expense_period_data_tables.py` had the same value for `down_revision`

Was this intentional? If not, this fixed it.