### PR TITLE
Hotfix: Merge two database heads causing backend error

### DIFF
--- a/backend/migrations/versions/eb0cfc570a8c_merging_two_heads.py
+++ b/backend/migrations/versions/eb0cfc570a8c_merging_two_heads.py
@@ -1,0 +1,24 @@
+"""merging two heads
+
+Revision ID: eb0cfc570a8c
+Revises: 5246e7e4cb55, ffb4c21d9d23
+Create Date: 2025-03-07 00:20:06.414649
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'eb0cfc570a8c'
+down_revision = ('5246e7e4cb55', 'ffb4c21d9d23')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Previously, the Python database code was crashing with the error:
```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
ERROR [flask_migrate] Error: Multiple head revisions are present for given argument 'head'; please specify a specific target revision, '<branchname>@head' to narrow to a specific head, or 'heads' for all heads
```

Quick fix by: setting "command" of docker-compose.yml to
`bash -c "flask db merge heads -m "merging two heads"` and then reverting back after running once, as per guide here: https://www.arundhaj.com/blog/multiple-head-revisions-present-error-flask-migrate.html